### PR TITLE
Make shebang portable in gperf.custom

### DIFF
--- a/gperf.custom
+++ b/gperf.custom
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #$1 function name
 #$2 define prefix
 #$3 input


### PR DESCRIPTION
On FreeBSD system, the build stage fails with the following error:

ports% ninja                                                                                                                                                                 
[1/25] Generating gperf hash_mods.h with a custom command.                                                                                                                   
FAILED: hash_mods.h                                                                                                                                                          
/usr/home/nivit/sviluppo/github/vbar/gperf.custom hash_mods HMODS_ ../gperf/mods.gperf hash_mods.h                                                                           
/bin/sh: /usr/home/nivit/sviluppo/github/vbar/gperf.custom: not found                                                                                                        
[2/25] Generating gperf hash_intp.h with a custom command.                                                                                                                   
FAILED: hash_intp.h                                                                                                                                                          
/usr/home/nivit/sviluppo/github/vbar/gperf.custom hash_intp HINTP_ ../gperf/intp.gperf hash_intp.h                                                                           
/bin/sh: /usr/home/nivit/sviluppo/github/vbar/gperf.custom: not found                                                                                                        
ninja: build stopped: subcommand failed.

because the bash shell is installed in /usr/local/bin and not in /usr/bin.