### PR TITLE
Fixed build in meson 0.48.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -143,7 +143,7 @@ endif
 # debug #
 #########
 
-opt_debug = get_option('debug')
+opt_debug = get_option('vbar-debug')
 if opt_debug > 0
   message('debug enabled')
   debugstr = '-DEF_DEBUG_ENABLE=@0@'
@@ -151,7 +151,7 @@ if opt_debug > 0
   add_global_arguments(debugstr, language: 'c')
 endif
 
-opt_debug_color = get_option('dolor')
+opt_debug_color = get_option('color')
 if opt_debug_color > 0
   message('color debug enabled')
   debugstr = '-DEF_DEBUG_COLOR=@0@'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('debug', type: 'integer', value: '0', description: 'set debug level, 0 disable 4 full')
+option('vbar-debug', type: 'integer', value: '0', description: 'set debug level, 0 disable 4 full')
 option('dolor', type: 'integer', value: '0', description: 'color debug, 0 disable 1 active')
 option('assert', type: 'integer', value: '1', description: 'enable assertion')
 option('optimize', type: 'integer', value: '1', description: 'enable optimization')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('vbar-debug', type: 'integer', value: '0', description: 'set debug level, 0 disable 4 full')
-option('dolor', type: 'integer', value: '0', description: 'color debug, 0 disable 1 active')
+option('color', type: 'integer', value: '0', description: 'color debug, 0 disable 1 active')
 option('assert', type: 'integer', value: '1', description: 'enable assertion')
 option('optimize', type: 'integer', value: '1', description: 'enable optimization')
 option('m-cpu-ncores', type: 'integer', value: '0', description: 'set max ncores available')


### PR DESCRIPTION
these commits fix the following error:
```
The Meson build system
 Version: 0.48.0
 Source dir: /path/to/vbar
 Build dir: /path/to/vbar/build
 Build type: native build

 meson_options.txt:1:0: ERROR:  Option name debug is reserved.
```
by using a different name for the debug option (in this case, vbar-debug).

I fixed also a typo (dolor instead of color)
